### PR TITLE
Refactor queue helpers and controller save hooks

### DIFF
--- a/modules/wmdk/wmdkffexportqueue/Traits/ProcessIpTrait.php
+++ b/modules/wmdk/wmdkffexportqueue/Traits/ProcessIpTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Wmdk\FactFinderQueue\Traits;
+
+use OxidEsales\Eshop\Core\Registry;
+
+trait ProcessIpTrait
+{
+    protected $_sProcessIp = null;
+
+    protected function _getProcessIp($sIp = false)
+    {
+        if ($sIp !== false) {
+            return (string) $sIp;
+        }
+
+        if ($this->_sProcessIp === null) {
+            $this->_sProcessIp = \wmdkffexport_helper::getClientIp();
+        }
+
+        return $this->_sProcessIp;
+    }
+
+    protected function _isCron(): bool
+    {
+        $sCronjobIpList = (string) Registry::getConfig()->getConfigParam('sWmdkFFDebugCronjobIpList');
+        $aCronjobIps = array_filter(array_map('trim', explode(',', $sCronjobIpList)));
+        $bCronjobIp = in_array($this->_getProcessIp(), $aCronjobIps, true);
+
+        return (php_sapi_name() === 'cli') || $bCronjobIp;
+    }
+}

--- a/modules/wmdk/wmdkffexportqueue/Traits/QueueArticleSaveTrait.php
+++ b/modules/wmdk/wmdkffexportqueue/Traits/QueueArticleSaveTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Wmdk\FactFinderQueue\Traits;
+
+use OxidEsales\Eshop\Core\Registry;
+
+trait QueueArticleSaveTrait
+{
+    protected function saveQueueArticleFromRequest(): void
+    {
+        $sOxid = Registry::getConfig()->getRequestParameter('oxid');
+
+        if ($sOxid !== null && $sOxid !== '') {
+            \wmdkffexport_helper::saveArticle((string) $sOxid);
+        }
+    }
+}

--- a/modules/wmdk/wmdkffexportqueue/controllers/admin/wmdkffqueuearticle_extend.php
+++ b/modules/wmdk/wmdkffexportqueue/controllers/admin/wmdkffqueuearticle_extend.php
@@ -1,10 +1,12 @@
 <?php
 
 
-use OxidEsales\Eshop\Core\Registry;
+use Wmdk\FactFinderQueue\Traits\QueueArticleSaveTrait;
 
 class wmdkFfQueueArticle_Extend extends wmdkFfQueueArticle_Extend_parent
 {
+    use QueueArticleSaveTrait;
+
     /**
      * Saves changes of article parameters.
      */
@@ -13,6 +15,6 @@ class wmdkFfQueueArticle_Extend extends wmdkFfQueueArticle_Extend_parent
         parent::save();
         
         // ACTIVE OXID
-        wmdkffexport_helper::saveArticle(Registry::getConfig()->getRequestParameter('oxid'));
+        $this->saveQueueArticleFromRequest();
     }
 }

--- a/modules/wmdk/wmdkffexportqueue/controllers/admin/wmdkffqueuearticle_files.php
+++ b/modules/wmdk/wmdkffexportqueue/controllers/admin/wmdkffqueuearticle_files.php
@@ -1,10 +1,12 @@
 <?php
 
 
-use OxidEsales\Eshop\Core\Registry;
+use Wmdk\FactFinderQueue\Traits\QueueArticleSaveTrait;
 
 class wmdkFfQueueArticle_Files extends wmdkFfQueueArticle_Files_parent
 {
+    use QueueArticleSaveTrait;
+
     /**
      * Saves changes of article parameters.
      */
@@ -13,6 +15,6 @@ class wmdkFfQueueArticle_Files extends wmdkFfQueueArticle_Files_parent
         parent::save();
         
         // ACTIVE OXID
-        wmdkffexport_helper::saveArticle(Registry::getConfig()->getRequestParameter('oxid'));
+        $this->saveQueueArticleFromRequest();
     }
 }

--- a/modules/wmdk/wmdkffexportqueue/controllers/admin/wmdkffqueuearticle_main.php
+++ b/modules/wmdk/wmdkffexportqueue/controllers/admin/wmdkffqueuearticle_main.php
@@ -1,10 +1,12 @@
 <?php
 
 
-use OxidEsales\Eshop\Core\Registry;
+use Wmdk\FactFinderQueue\Traits\QueueArticleSaveTrait;
 
 class wmdkFfQueueArticle_Main extends wmdkFfQueueArticle_Main_parent
 {
+    use QueueArticleSaveTrait;
+
     /**
      * Saves changes of article parameters.
      */
@@ -13,6 +15,6 @@ class wmdkFfQueueArticle_Main extends wmdkFfQueueArticle_Main_parent
         parent::save();
         
         // ACTIVE OXID
-        wmdkffexport_helper::saveArticle(Registry::getConfig()->getRequestParameter('oxid'));
+        $this->saveQueueArticleFromRequest();
     }
 }

--- a/modules/wmdk/wmdkffexportqueue/controllers/admin/wmdkffqueuearticle_pictures.php
+++ b/modules/wmdk/wmdkffexportqueue/controllers/admin/wmdkffqueuearticle_pictures.php
@@ -1,10 +1,12 @@
 <?php
 
 
-use OxidEsales\Eshop\Core\Registry;
+use Wmdk\FactFinderQueue\Traits\QueueArticleSaveTrait;
 
 class wmdkFfQueueArticle_Pictures extends wmdkFfQueueArticle_Pictures_parent
 {
+    use QueueArticleSaveTrait;
+
     /**
      * Saves changes of article parameters.
      */
@@ -13,6 +15,6 @@ class wmdkFfQueueArticle_Pictures extends wmdkFfQueueArticle_Pictures_parent
         parent::save();
         
         // ACTIVE OXID
-        wmdkffexport_helper::saveArticle(Registry::getConfig()->getRequestParameter('oxid'));
+        $this->saveQueueArticleFromRequest();
     }
 }

--- a/modules/wmdk/wmdkffexportqueue/controllers/admin/wmdkffqueuearticle_review.php
+++ b/modules/wmdk/wmdkffexportqueue/controllers/admin/wmdkffqueuearticle_review.php
@@ -1,10 +1,12 @@
 <?php
 
 
-use OxidEsales\Eshop\Core\Registry;
+use Wmdk\FactFinderQueue\Traits\QueueArticleSaveTrait;
 
 class wmdkFfQueueArticle_Review extends wmdkFfQueueArticle_Review_parent
 {
+    use QueueArticleSaveTrait;
+
     /**
      * Saves changes of article parameters.
      */
@@ -13,6 +15,6 @@ class wmdkFfQueueArticle_Review extends wmdkFfQueueArticle_Review_parent
         parent::save();
         
         // ACTIVE OXID
-        wmdkffexport_helper::saveArticle(Registry::getConfig()->getRequestParameter('oxid'));
+        $this->saveQueueArticleFromRequest();
     }
 }

--- a/modules/wmdk/wmdkffexportqueue/controllers/admin/wmdkffqueuearticle_seo.php
+++ b/modules/wmdk/wmdkffexportqueue/controllers/admin/wmdkffqueuearticle_seo.php
@@ -1,10 +1,12 @@
 <?php
 
 
-use OxidEsales\Eshop\Core\Registry;
+use Wmdk\FactFinderQueue\Traits\QueueArticleSaveTrait;
 
 class wmdkFfQueueArticle_Seo extends wmdkFfQueueArticle_Seo_parent
 {
+    use QueueArticleSaveTrait;
+
     /**
      * Saves changes of article parameters.
      */
@@ -13,6 +15,6 @@ class wmdkFfQueueArticle_Seo extends wmdkFfQueueArticle_Seo_parent
         parent::save();
         
         // ACTIVE OXID
-        wmdkffexport_helper::saveArticle(Registry::getConfig()->getRequestParameter('oxid'));
+        $this->saveQueueArticleFromRequest();
     }
 }

--- a/modules/wmdk/wmdkffexportqueue/controllers/admin/wmdkffqueuearticle_stock.php
+++ b/modules/wmdk/wmdkffexportqueue/controllers/admin/wmdkffqueuearticle_stock.php
@@ -1,10 +1,12 @@
 <?php
 
 
-use OxidEsales\Eshop\Core\Registry;
+use Wmdk\FactFinderQueue\Traits\QueueArticleSaveTrait;
 
 class wmdkFfQueueArticle_Stock extends wmdkFfQueueArticle_Stock_parent
 {
+    use QueueArticleSaveTrait;
+
     /**
      * Saves changes of article parameters.
      */
@@ -13,6 +15,6 @@ class wmdkFfQueueArticle_Stock extends wmdkFfQueueArticle_Stock_parent
         parent::save();
         
         // ACTIVE OXID
-        wmdkffexport_helper::saveArticle(Registry::getConfig()->getRequestParameter('oxid'));
+        $this->saveQueueArticleFromRequest();
     }
 }

--- a/modules/wmdk/wmdkffexportqueue/controllers/admin/wmdkffqueuearticle_variant.php
+++ b/modules/wmdk/wmdkffexportqueue/controllers/admin/wmdkffqueuearticle_variant.php
@@ -2,9 +2,12 @@
 
 
 use OxidEsales\Eshop\Core\Registry;
+use Wmdk\FactFinderQueue\Traits\QueueArticleSaveTrait;
 
 class wmdkFfQueueArticle_Variant extends wmdkFfQueueArticle_Variant_parent
 {
+    use QueueArticleSaveTrait;
+
     /**
      * Saves changes of article parameters.
      */
@@ -13,7 +16,7 @@ class wmdkFfQueueArticle_Variant extends wmdkFfQueueArticle_Variant_parent
         parent::savevariants();
         
         // ACTIVE OXID
-        wmdkffexport_helper::saveArticle(Registry::getConfig()->getRequestParameter('oxid'));
+        $this->saveQueueArticleFromRequest();
     }
 
     public function getMappingOptions()

--- a/modules/wmdk/wmdkffexportqueue/core/wmdkffexport_helper.php
+++ b/modules/wmdk/wmdkffexportqueue/core/wmdkffexport_helper.php
@@ -6,6 +6,8 @@ declare(strict_types=1);
  */
 class wmdkffexport_helper
 {
+    private const QUEUE_TABLE = 'wmdk_ff_export_queue';
+    private const NULL_DATE = '0000-00-00 00:00:00';
     
     public static function saveArticle(string $sOxid): void
     {
@@ -98,7 +100,7 @@ class wmdkffexport_helper
         $sQuery = 'SELECT 
             count(*)
         FROM 
-            `wmdk_ff_export_queue`
+            `' . self::QUEUE_TABLE . '`
         WHERE
             (`OXID` = ' . $oDb->quote($sOxid) . ')
             AND (`Channel` = ' . $oDb->quote($sChannel) . ')
@@ -119,7 +121,7 @@ class wmdkffexport_helper
     {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sQuery = 'INSERT INTO 
-            `wmdk_ff_export_queue` 
+            `' . self::QUEUE_TABLE . '` 
         ( 
             `OXID`,
             `Channel`,
@@ -136,9 +138,9 @@ class wmdkffexport_helper
             ' . $oDb->quote($sChannel) . ',
             ' . (int) $iShopId . ',
             ' . (int) $iLang . ',
-            "0000-00-00 00:00:00",
+            "' . self::NULL_DATE . '",
             ' . $oDb->quote(self::getClientIp()) . ',
-            "0000-00-00 00:00:00",
+            "' . self::NULL_DATE . '",
             "1"
         );';
         
@@ -163,11 +165,11 @@ class wmdkffexport_helper
     ): void {
         $oDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
         $sQuery = 'UPDATE 
-            `wmdk_ff_export_queue` 
+            `' . self::QUEUE_TABLE . '` 
         SET 
-            `LASTSYNC` = "0000-00-00 00:00:00",
+            `LASTSYNC` = "' . self::NULL_DATE . '",
             `ProcessIp` = ' . $oDb->quote(self::getClientIp()) . ',
-            `OXTIMESTAMP` = "0000-00-00 00:00:00",
+            `OXTIMESTAMP` = "' . self::NULL_DATE . '",
             `OXACTIVE` = "' . (int) $iActive . '"
         WHERE 
             (`OXID` = ' . $oDb->quote($sOxid) . ')

--- a/modules/wmdk/wmdkffexportqueue/views/wmdkffexport_ajax.php
+++ b/modules/wmdk/wmdkffexportqueue/views/wmdkffexport_ajax.php
@@ -2,6 +2,7 @@
 
 use OxidEsales\Eshop\Core\DatabaseProvider;
 use OxidEsales\Eshop\Core\Registry;
+use Wmdk\FactFinderQueue\Traits\ProcessIpTrait;
 use Wmdk\FactFinderQueue\Traits\Ajax\ResetTrait;
 
 /**
@@ -10,6 +11,7 @@ use Wmdk\FactFinderQueue\Traits\Ajax\ResetTrait;
 class wmdkffexport_ajax extends oxubase
 {
     use ResetTrait;
+    use ProcessIpTrait;
 
     protected $_aResponse = array(
         'success' => TRUE,
@@ -19,8 +21,6 @@ class wmdkffexport_ajax extends oxubase
         'validation_errors' => array(),
         'system_errors' => array(),
     );
-    
-    protected $_sProcessIp = NULL;
     
     protected $_sTemplate = 'wmdkffexport_ajax.tpl';
 
@@ -52,32 +52,6 @@ class wmdkffexport_ajax extends oxubase
         }
 
         return $this->_sTemplate;
-    }
-    
-    
-    private function _getProcessIp($sIp = FALSE) {
-        if ($this->_sProcessIp == NULL) {
-            
-            if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
-                $this->_sProcessIp = $_SERVER['HTTP_CLIENT_IP'];
-                
-            } elseif (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-                $this->_sProcessIp = $_SERVER['HTTP_X_FORWARDED_FOR'];
-                
-            } else {
-                $this->_sProcessIp = $_SERVER['REMOTE_ADDR'];
-            }
-            
-        }
-        
-        return ($sIp != FALSE) ? $sIp : $this->_sProcessIp;
-    }
-    
-    
-    private function _isCron() {
-        $sIsCronjobOrg = in_array( $this->_getProcessIp(), explode(',', Registry::getConfig()->getConfigParam('sWmdkFFDebugCronjobIpList') ) );
-        
-        return ( (php_sapi_name() == 'cli') || $sIsCronjobOrg);
     }
     
     

--- a/modules/wmdk/wmdkffexportqueue/views/wmdkffexport_queue.php
+++ b/modules/wmdk/wmdkffexportqueue/views/wmdkffexport_queue.php
@@ -5,6 +5,7 @@ use OxidEsales\Eshop\Core\Registry;
 use Wmdk\FactFinderQueue\Traits\ClonedAttributesTrait;
 use Wmdk\FactFinderQueue\Traits\ConverterTrait;
 use Wmdk\FactFinderQueue\Traits\FlourTrait;
+use Wmdk\FactFinderQueue\Traits\ProcessIpTrait;
 
 /**
  * Class wmdkffexport_queue
@@ -14,6 +15,7 @@ class wmdkffexport_queue extends oxubase
     use ClonedAttributesTrait;
     use ConverterTrait;
     use FlourTrait;
+    use ProcessIpTrait;
 
     CONST DEFAULT_TAX_RATE = 19;
 
@@ -54,8 +56,6 @@ class wmdkffexport_queue extends oxubase
         'validation_errors' => array(),
         'system_errors' => array(),
     );
-    
-    protected $_sProcessIp = NULL;
     
     protected $_sTemplate = 'wmdkffexport_queue.tpl';
     
@@ -776,25 +776,6 @@ class wmdkffexport_queue extends oxubase
     }
     
     
-    private function _getProcessIp($sIp = FALSE) {
-        if ($this->_sProcessIp == NULL) {
-            
-            if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
-                $this->_sProcessIp = $_SERVER['HTTP_CLIENT_IP'];
-                
-            } elseif (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-                $this->_sProcessIp = $_SERVER['HTTP_X_FORWARDED_FOR'];
-                
-            } else {
-                $this->_sProcessIp = $_SERVER['REMOTE_ADDR'];
-            }
-            
-        }
-        
-        return ($sIp != FALSE) ? $sIp : $this->_sProcessIp;
-    }
-    
-    
     private function _getSqlUpdateString() {
         $aAttributes = array();
         
@@ -854,13 +835,6 @@ class wmdkffexport_queue extends oxubase
     
     private function _removeCronjobFlag() {
         return unlink($this->_sCronjobFlagname);
-    }
-    
-    
-    private function _isCron() {
-        $sIsCronjobOrg = in_array( $this->_getProcessIp(), explode(',', Registry::getConfig()->getConfigParam('sWmdkFFDebugCronjobIpList') ) );
-        
-        return ( (php_sapi_name() == 'cli') || $sIsCronjobOrg);
     }
     
     

--- a/modules/wmdk/wmdkffexportqueue/views/wmdkffexport_reset.php
+++ b/modules/wmdk/wmdkffexportqueue/views/wmdkffexport_reset.php
@@ -2,12 +2,15 @@
 
 use OxidEsales\Eshop\Core\DatabaseProvider;
 use OxidEsales\Eshop\Core\Registry;
+use Wmdk\FactFinderQueue\Traits\ProcessIpTrait;
 
 /**
  * Class wmdkffexport_reset
  */
 class wmdkffexport_reset extends oxubase
-{    
+{
+    use ProcessIpTrait;
+
     protected $_aResponse = array(
         'success' => TRUE,
 
@@ -25,8 +28,6 @@ class wmdkffexport_reset extends oxubase
         'validation_errors' => array(),
         'system_errors' => array(),
     );
-    
-    protected $_sProcessIp = NULL;
     
     protected $_sTemplate = 'wmdkffexport_reset.tpl';
 
@@ -493,32 +494,6 @@ class wmdkffexport_reset extends oxubase
             // LOG
             $this->_aResponse['disable_missing_oxids'] = FALSE;
         }
-    }
-    
-    
-    private function _getProcessIp($sIp = FALSE) {
-        if ($this->_sProcessIp == NULL) {
-            
-            if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
-                $this->_sProcessIp = $_SERVER['HTTP_CLIENT_IP'];
-                
-            } elseif (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-                $this->_sProcessIp = $_SERVER['HTTP_X_FORWARDED_FOR'];
-                
-            } else {
-                $this->_sProcessIp = $_SERVER['REMOTE_ADDR'];
-            }
-            
-        }
-        
-        return ($sIp != FALSE) ? $sIp : $this->_sProcessIp;
-    }
-    
-    
-    private function _isCron() {
-        $sIsCronjobOrg = in_array( $this->_getProcessIp(), explode(',', Registry::getConfig()->getConfigParam('sWmdkFFDebugCronjobIpList') ) );
-        
-        return ( (php_sapi_name() == 'cli') || $sIsCronjobOrg);
     }
     
     

--- a/modules/wmdk/wmdkffexportqueue/views/wmdkffexport_ts.php
+++ b/modules/wmdk/wmdkffexportqueue/views/wmdkffexport_ts.php
@@ -1,12 +1,15 @@
 <?php
 
 use OxidEsales\Eshop\Core\Registry;
+use Wmdk\FactFinderQueue\Traits\ProcessIpTrait;
 
 /**
  * Class wmdkffexport_ts
  */
 class wmdkffexport_ts extends oxubase
 {    
+    use ProcessIpTrait;
+
     protected $_aResponse = array(
         'success' => TRUE,
 
@@ -23,8 +26,6 @@ class wmdkffexport_ts extends oxubase
     );
     
     private $_sChannel = 'wh1_live_de';
-    
-    protected $_sProcessIp = NULL;
     
     protected $_sApiUrl = NULL;
     
@@ -286,32 +287,6 @@ class wmdkffexport_ts extends oxubase
         
         // LOG
         $this->_aResponse['reviews_copied'] = $iCopied;
-    }
-    
-    
-    private function _getProcessIp($sIp = FALSE) {
-        if ($this->_sProcessIp == NULL) {
-            
-            if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
-                $this->_sProcessIp = $_SERVER['HTTP_CLIENT_IP'];
-                
-            } elseif (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-                $this->_sProcessIp = $_SERVER['HTTP_X_FORWARDED_FOR'];
-                
-            } else {
-                $this->_sProcessIp = $_SERVER['REMOTE_ADDR'];
-            }
-            
-        }
-        
-        return ($sIp != FALSE) ? $sIp : $this->_sProcessIp;
-    }
-    
-    
-    private function _isCron() {
-        $sIsCronjobOrg = in_array( $this->_getProcessIp(), explode(',', Registry::getConfig()->getConfigParam('sWmdkFFDebugCronjobIpList') ) );
-        
-        return ( (php_sapi_name() == 'cli') || $sIsCronjobOrg);
     }
     
     


### PR DESCRIPTION
### Motivation
- Remove duplicated process IP / cron-detection logic present in multiple view classes by centralizing it in a reusable trait. 
- Consolidate identical article-save hooks across admin article controllers into a single shared implementation to reduce boilerplate. 
- Make SQL construction in the queue helper less error-prone by introducing reusable constants for table name and null date values.

### Description
- Add `Wmdk\FactFinderQueue\Traits\ProcessIpTrait` which provides `_getProcessIp()` and `_isCron()` and is now used by `wmdkffexport_queue`, `wmdkffexport_ts`, `wmdkffexport_reset`, and `wmdkffexport_ajax` to replace duplicated logic. 
- Add `Wmdk\FactFinderQueue\Traits\QueueArticleSaveTrait` with `saveQueueArticleFromRequest()` and apply it to the admin controllers (`wmdkffqueuearticle_main`, `_extend`, `_files`, `_pictures`, `_review`, `_seo`, `_stock`, `_variant`) to consolidate `wmdkffexport_helper::saveArticle(...)` calls. 
- Introduce `QUEUE_TABLE` and `NULL_DATE` constants in `wmdkffexport_helper` and update its SQL strings to use these constants instead of hard-coded literals, and keep `getClientIp()` usage centralized. 
- Minor namespace/backslash fixes so helper calls are fully-qualified where used in the new traits.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f32e066348332a07f66ecee70f4c5)