### PR TITLE
Refactor queue SQL, add cron lock trait, and harden TS import

### DIFF
--- a/modules/wmdk/wmdkffexportqueue/Traits/CronLockTrait.php
+++ b/modules/wmdk/wmdkffexportqueue/Traits/CronLockTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Wmdk\FactFinderQueue\Traits;
+
+trait CronLockTrait
+{
+    protected $_sCronjobFlagname = null;
+
+    protected function _getCronjobFlagPath(string $sFlagname = '/tmp/wmdk_ff_cron.flag'): string
+    {
+        $this->_sCronjobFlagname = str_replace('//', '/', $_SERVER['DOCUMENT_ROOT'] . $sFlagname);
+
+        return $this->_sCronjobFlagname;
+    }
+
+    protected function _hasCronjobFlag(string $sFlagname = '/tmp/wmdk_ff_cron.flag'): bool
+    {
+        return file_exists($this->_getCronjobFlagPath($sFlagname));
+    }
+
+    protected function _setCronjobFlag(string $sFlagname = '/tmp/wmdk_ff_cron.flag'): void
+    {
+        $sFlagPath = $this->_getCronjobFlagPath($sFlagname);
+        file_put_contents($sFlagPath, '');
+    }
+
+    protected function _removeCronjobFlag(): bool
+    {
+        if ($this->_sCronjobFlagname === null || !file_exists($this->_sCronjobFlagname)) {
+            return false;
+        }
+
+        return unlink($this->_sCronjobFlagname);
+    }
+}

--- a/modules/wmdk/wmdkffexportqueue/core/wmdkffexport_helper.php
+++ b/modules/wmdk/wmdkffexportqueue/core/wmdkffexport_helper.php
@@ -45,8 +45,8 @@ class wmdkffexport_helper
     public static function touchVariants(string $sOxid): void
     {
         // LOAD VARIANTS
-        $sQuery = 'SELECT OXID, OXACTIVE FROM `oxarticles` WHERE OXPARENTID = "' . $sOxid . '" ORDER BY OXVARSELECT ASC;';  
-        $oResult = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(false)->select($sQuery);
+        $sQuery = 'SELECT OXID, OXACTIVE FROM `oxarticles` WHERE OXPARENTID = ? ORDER BY OXVARSELECT ASC;';
+        $oResult = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(false)->select($sQuery, array($sOxid));
 
         if ($oResult !== false && $oResult->count() > 0) {
 
@@ -102,12 +102,12 @@ class wmdkffexport_helper
         FROM 
             `' . self::QUEUE_TABLE . '`
         WHERE
-            (`OXID` = ' . $oDb->quote($sOxid) . ')
-            AND (`Channel` = ' . $oDb->quote($sChannel) . ')
-            AND (`OXSHOPID` = ' . (int) $iShopId . ')
-            AND (`LANG` = ' . (int) $iLang . ');';
+            (`OXID` = ?)
+            AND (`Channel` = ?)
+            AND (`OXSHOPID` = ?)
+            AND (`LANG` = ?);';
         
-        $oResult = $oDb->select($sQuery);
+        $oResult = $oDb->select($sQuery, array($sOxid, $sChannel, (int) $iShopId, (int) $iLang));
         
         if ($oResult !== false && $oResult->count() > 0) {
             return ((int) $oResult->fields[0] > 0);
@@ -134,25 +134,36 @@ class wmdkffexport_helper
         ) 
         VALUES
         (
-            ' . $oDb->quote($sOxid) . ',
-            ' . $oDb->quote($sChannel) . ',
-            ' . (int) $iShopId . ',
-            ' . (int) $iLang . ',
-            "' . self::NULL_DATE . '",
-            ' . $oDb->quote(self::getClientIp()) . ',
-            "' . self::NULL_DATE . '",
-            "1"
+            ?,
+            ?,
+            ?,
+            ?,
+            ?,
+            ?,
+            ?,
+            ?
         );';
-        
-        // UPDATE oxarticles.WMDK_FFQUEUE   
-        $sQuery .= 'UPDATE
+
+        $oDb->execute($sQuery, array(
+            $sOxid,
+            $sChannel,
+            (int) $iShopId,
+            (int) $iLang,
+            self::NULL_DATE,
+            self::getClientIp(),
+            self::NULL_DATE,
+            1,
+        ));
+
+        // UPDATE oxarticles.WMDK_FFQUEUE
+        $sQuery = 'UPDATE
             oxarticles
         SET
             WMDK_FFQUEUE = "1"
         WHERE
-            OXID = ' . $oDb->quote($sOxid) . ';';
-        
-        $oDb->execute($sQuery);
+            OXID = ?;';
+
+        $oDb->execute($sQuery, array($sOxid));
     }
     
     
@@ -167,17 +178,26 @@ class wmdkffexport_helper
         $sQuery = 'UPDATE 
             `' . self::QUEUE_TABLE . '` 
         SET 
-            `LASTSYNC` = "' . self::NULL_DATE . '",
-            `ProcessIp` = ' . $oDb->quote(self::getClientIp()) . ',
-            `OXTIMESTAMP` = "' . self::NULL_DATE . '",
-            `OXACTIVE` = "' . (int) $iActive . '"
+            `LASTSYNC` = ?,
+            `ProcessIp` = ?,
+            `OXTIMESTAMP` = ?,
+            `OXACTIVE` = ?
         WHERE 
-            (`OXID` = ' . $oDb->quote($sOxid) . ')
-            AND (`Channel` = ' . $oDb->quote($sChannel) . ')
-            AND (`OXSHOPID` = ' . (int) $iShopId . ')
-            AND (`LANG` = ' . (int) $iLang . ');';
+            (`OXID` = ?)
+            AND (`Channel` = ?)
+            AND (`OXSHOPID` = ?)
+            AND (`LANG` = ?);';
         
-        $oDb->execute($sQuery);
+        $oDb->execute($sQuery, array(
+            self::NULL_DATE,
+            self::getClientIp(),
+            self::NULL_DATE,
+            (int) $iActive,
+            $sOxid,
+            $sChannel,
+            (int) $iShopId,
+            (int) $iLang,
+        ));
     }
     
     

--- a/modules/wmdk/wmdkffexportqueue/sql/install.sql
+++ b/modules/wmdk/wmdkffexportqueue/sql/install.sql
@@ -70,6 +70,8 @@ CREATE TABLE IF NOT EXISTS `wmdk_ff_export_queue` (
     KEY `ProductNumber` (`ProductNumber`),
     KEY `MasterProductNumber` (`MasterProductNumber`),
     KEY `LASTSYNC` (`LASTSYNC`),
+    KEY `Stock` (`Stock`),
+    KEY `idx_queue_sync` (`OXACTIVE`, `Stock`, `LASTSYNC`),
     KEY `EAN` (`EAN`),
     KEY `idx_attributes` (`Attributes`(255)),
     KEY `idx_clonedattributes` (`ClonedAttributes`(255))

--- a/modules/wmdk/wmdkffexportqueue/sql/update.sql
+++ b/modules/wmdk/wmdkffexportqueue/sql/update.sql
@@ -2,6 +2,11 @@
 SET FOREIGN_KEY_CHECKS = 0;
 
 -- Update data OXARTICLES
+ALTER TABLE `wmdk_ff_export_queue`
+	ADD INDEX `Stock` (`Stock`),
+	ADD INDEX `idx_queue_sync` (`OXACTIVE`, `Stock`, `LASTSYNC`);
+
+-- Update data OXARTICLES
 UPDATE
 	oxarticles a,
 	wmdk_ff_export_queue b


### PR DESCRIPTION
### Motivation
- Reduce fragile concatenated SQL and improve safety by using parameterized queries for queue operations and helper functions.
- Avoid very large multi-statement update blobs by batching updates to improve error visibility and avoid query length limits.
- Centralize cron lock handling so the queue controller no longer manages raw flag files inline.
- Improve Trusted Shops import resiliency by adding timeouts and retry logic and make review DB updates parameterized.
- Improve selection performance for large queues by adding indexes supporting the common selection filters and sort.

### Description
- Added a reusable `CronLockTrait` and switched the queue controller to use it instead of inline flag file handling (new file `Traits/CronLockTrait.php` and updates to `views/wmdkffexport_queue.php`).
- Replaced concatenated update generation in `views/wmdkffexport_queue.php` with a parameterized update builder and store per-row prepared SQL+params in `_aPreparedUpdateQueries`, then execute in batches (default `100`) to avoid large multi-queries.
- Converted helper DB operations in `core/wmdkffexport_helper.php` to use parameterized `select`/`execute` calls for `touchVariants`, `isInQueue`, `insertArticle`, and `updateArticle`.
- Hardened Trusted Shops import in `views/wmdkffexport_ts.php` by adding `_fetchTrustedShopsResponse()` with a configurable timeout and retry/backoff loop, JSON validation, and converted review-related DB updates/inserts to use parameterized queries.
- Added index additions to `sql/install.sql` and `sql/update.sql` (`Stock` and composite `idx_queue_sync (OXACTIVE, Stock, LASTSYNC)`) to make queue selection and ordering more index-friendly.

### Testing
- No automated tests were run as part of this change (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f3c2003c08332ae94a5e619eeac1a)