### PR TITLE
Add OXID Testing Library unit tests and test instructions

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -63,6 +63,23 @@ the HTTP endpoints but avoids having to call `index.php` via HTTP.
    php source/bin/wmdkffexport.php flour --channel=wh1_live_de --shop-id=1 --lang=0 --flour-id=1
    ```
 
+## Testing (OXID Testing Library)
+
+The module ships with unit tests that use the OXID Testing Library. Run them from the shop
+root where the module is installed.
+
+1. Install the testing library (if it is not already available):
+
+   ```bash
+   composer require --dev oxid-esales/testing-library
+   ```
+
+2. Execute the module unit tests:
+
+   ```bash
+   vendor/bin/phpunit --bootstrap vendor/oxid-esales/testing-library/bootstrap.php modules/wmdk/wmdkffexportqueue/tests/Unit
+   ```
+
 ## Bash Commands (Modes)
 
 ### Queue (default)

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,9 @@
         "spatie/array-to-xml": "^2.7",
         "ext-zlib": "*"
     },
+    "require-dev": {
+        "oxid-esales/testing-library": "^8.0"
+    },
     "autoload":    {
         "psr-4": {
             "Wmdk\\FactFinderQueue\\": "../../../source/modules/wmdk/wmdkffexportqueue"

--- a/modules/wmdk/wmdkffexportqueue/tests/Unit/wmdkffexport_helperTest.php
+++ b/modules/wmdk/wmdkffexportqueue/tests/Unit/wmdkffexport_helperTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use OxidEsales\Eshop\Core\Registry;
+use OxidEsales\TestingLibrary\UnitTestCase;
+
+require_once __DIR__ . '/../../core/wmdkffexport_helper.php';
+
+class wmdkffexport_helperTest extends UnitTestCase
+{
+    public function testGetChannelListParsesConfiguredChannels(): void
+    {
+        $config = Registry::getConfig();
+        $original = $config->getConfigParam('sWmdkFFGeneralChannelList');
+        $config->setConfigParam('sWmdkFFGeneralChannelList', 'demo::1::0, de::2::1, onlycode');
+
+        try {
+            $channels = wmdkffexport_helper::getChannelList();
+        } finally {
+            $config->setConfigParam('sWmdkFFGeneralChannelList', $original);
+        }
+
+        $this->assertSame(
+            array(
+                array('code' => 'demo', 'shop_id' => 1, 'lang_id' => 0),
+                array('code' => 'de', 'shop_id' => 2, 'lang_id' => 1),
+                array('code' => 'onlycode', 'shop_id' => 0, 'lang_id' => 0),
+            ),
+            $channels
+        );
+    }
+
+    public function testGetClientIpUsesForwardedHeader(): void
+    {
+        $originalServer = $_SERVER ?? array();
+        $_SERVER = array(
+            'HTTP_X_FORWARDED_FOR' => '203.0.113.5, 70.41.3.18',
+        );
+
+        try {
+            $clientIp = wmdkffexport_helper::getClientIp();
+        } finally {
+            $_SERVER = $originalServer;
+        }
+
+        $this->assertSame('203.0.113.5', $clientIp);
+        $this->assertSame('198.51.100.10', wmdkffexport_helper::getClientIp('198.51.100.10'));
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide automated coverage for core helper utilities to prevent regressions in channel parsing and client IP resolution.
- Make it easy for contributors and CI to run module tests by documenting the test workflow in the user guide.
- Ensure the module declares the test framework as a development dependency so tests can be executed reproducibly.

### Description

- Add unit tests file `modules/wmdk/wmdkffexportqueue/tests/Unit/wmdkffexport_helperTest.php` that verifies `wmdkffexport_helper::getChannelList()` parsing and `wmdkffexport_helper::getClientIp()` behavior.
- Add the OXID Testing Library as a dev dependency in `composer.json` under `require-dev` (`oxid-esales/testing-library` ^8.0).
- Document how to install the testing library and run the module tests in `USER_GUIDE.md` with the commands `composer require --dev oxid-esales/testing-library` and `vendor/bin/phpunit --bootstrap vendor/oxid-esales/testing-library/bootstrap.php modules/wmdk/wmdkffexportqueue/tests/Unit`.

### Testing

- No automated tests were executed as part of this change; the patch only adds tests and test instructions (run tests locally or in CI with the documented `phpunit` command).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f80a00c3483328efb2fbd84aac378)